### PR TITLE
Fix a typo in the sim/README.md

### DIFF
--- a/sim/README.md
+++ b/sim/README.md
@@ -1,6 +1,6 @@
 Make sure actual video files are stored in `video_server/video[1-6]`, then run
 ```
-python get_video_sizes
+python get_video_sizes.py
 ```
 
 Put training data in `sim/cooked_traces` and testing data in `sim/cooked_test_traces` (need to create folders). The trace format for simulation is `[time_stamp (sec), throughput (Mbit/sec)]`. Sample training/testing data we used can be downloaded separately from `train_sim_traces` and `test_sim_traces` in https://www.dropbox.com/sh/ss0zs1lc4cklu3u/AAB-8WC3cHD4PTtYT0E4M19Ja?dl=0. More details of data preparation can be found in `traces/`.


### PR DESCRIPTION
The command 'python get_video_sizes' is not workable.